### PR TITLE
updated the name of variable coming from Runway for GPT2 example

### DIFF
--- a/GPT2/gpt2.js
+++ b/GPT2/gpt2.js
@@ -75,8 +75,8 @@ function draw(){
 }
 
 function newDrawing(data){
-    if(data && data.text) {
-      output_text = data.text;
+    if(data && data.generated_text) {
+      output_text = data.generated_text;
     }
 }
 


### PR DESCRIPTION
When I tried running the original code, it wasn't showing the generated text from Runway. After looking into it, I noticed that the json on Runway is specified as `generated_text` instead of `text`. I updated the code accordingly, and it was working fine so I thought I'd create a pull request so that others can benefit. Thank you.